### PR TITLE
fix: オンボーディング状態をIndexedDBに移行

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,8 @@ interface ThemeColors {
     - `calendar:settings`: アプリ設定
     - `calendar:comments`: 月ごとのコメント
     - `calendar:themes`: 月ごとのテーマ
+    - `calendar:gridStyles`: 月ごとのグリッドスタイル
+    - `onboarding:dismissed`: オンボーディングツールチップの表示済みフラグ
 
 ## データ管理
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -5,15 +5,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { useCalendarStore } from '../lib/store'
 import { APP_THEMES } from '../lib/types'
+import { loadOnboardingDismissed, saveOnboardingDismissed } from '../lib/storage'
 
 const PAGES = [
   { path: '/calendar', titleKey: 'app.title' },
   { path: '/qr', titleKey: 'app.titleQR' },
 ] as const
 
-const TIP_DISMISSED_KEYS: Record<string, string> = {
-  '/calendar': '3min-qr-tip-dismissed',
-  '/qr': '3min-calendar-tip-dismissed',
+const TIP_KEYS: Record<string, string> = {
+  '/calendar': 'qrTip',
+  '/qr': 'calendarTip',
 }
 
 const TIP_TRANSLATION_KEYS: Record<string, string> = {
@@ -48,31 +49,57 @@ export function AppHeader() {
     }
   }, [isOpen])
 
+  // オンボーディング dismissed 状態のキャッシュ
+  const dismissedRef = useRef<Record<string, boolean>>({})
+
   // 初回のみツールチップを表示（各ページで兄弟機能を案内）
   useEffect(() => {
-    const dismissedKey = TIP_DISMISSED_KEYS[location.pathname]
-    if (!dismissedKey) {
+    const tipKey = TIP_KEYS[location.pathname]
+    if (!tipKey) {
       setShowQrTip(false)
       return
     }
-    const dismissed = localStorage.getItem(dismissedKey)
-    if (dismissed) return
 
-    setShowQrTip(true)
+    let cancelled = false
+
+    const checkAndShow = async () => {
+      try {
+        const dismissed = await loadOnboardingDismissed()
+        dismissedRef.current = dismissed
+        if (cancelled || dismissed[tipKey]) return
+
+        setShowQrTip(true)
+      } catch {
+        // DB読み込み失敗時はツールチップを出さない
+      }
+    }
+    checkAndShow()
+
     const timer = setTimeout(() => {
-      setShowQrTip(false)
-      localStorage.setItem(dismissedKey, '1')
+      if (!cancelled) {
+        setShowQrTip(false)
+        dismissedRef.current[tipKey] = true
+        saveOnboardingDismissed(dismissedRef.current)
+      }
     }, 5000)
+
     return () => {
+      cancelled = true
       clearTimeout(timer)
-      localStorage.setItem(dismissedKey, '1')
+      if (dismissedRef.current[tipKey] !== true) {
+        dismissedRef.current[tipKey] = true
+        saveOnboardingDismissed(dismissedRef.current)
+      }
     }
   }, [location.pathname])
 
   const dismissTip = () => {
     setShowQrTip(false)
-    const dismissedKey = TIP_DISMISSED_KEYS[location.pathname]
-    if (dismissedKey) localStorage.setItem(dismissedKey, '1')
+    const tipKey = TIP_KEYS[location.pathname]
+    if (tipKey) {
+      dismissedRef.current[tipKey] = true
+      saveOnboardingDismissed(dismissedRef.current)
+    }
   }
 
   const handleSelect = (path: string) => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -250,6 +250,35 @@ export async function saveCalendarGridStyles(gridStyles: CalendarGridStyles): Pr
   })
 }
 
+/** オンボーディングの dismissed 状態を読み込み */
+export async function loadOnboardingDismissed(): Promise<Record<string, boolean>> {
+  const database = await openDB()
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(OBJECT_STORE_DATA, 'readonly')
+    const store = transaction.objectStore(OBJECT_STORE_DATA)
+    const request = store.get('onboarding:dismissed')
+
+    request.onerror = () => reject(request.error)
+    request.onsuccess = () => {
+      const result = request.result as { key: string; value: Record<string, boolean> } | undefined
+      resolve(result?.value || {})
+    }
+  })
+}
+
+/** オンボーディングの dismissed 状態を保存 */
+export async function saveOnboardingDismissed(dismissed: Record<string, boolean>): Promise<void> {
+  const database = await openDB()
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(OBJECT_STORE_DATA, 'readwrite')
+    const store = transaction.objectStore(OBJECT_STORE_DATA)
+    const request = store.put({ key: 'onboarding:dismissed', value: dismissed })
+
+    request.onerror = () => reject(request.error)
+    request.onsuccess = () => resolve()
+  })
+}
+
 /** エクスポート用データ構造 */
 export interface ExportData {
   version: number


### PR DESCRIPTION
## 関連 Issue
#23 の追加修正

## 変更内容
- オンボーディングのdismissed状態をlocalStorageからIndexedDB（`data`ストア、`onboarding:dismissed`キー）に移行
- 既存のデータ保存パターン（`calendar:settings`等）と統一
- `docs/architecture.md` のIndexedDB構造に `onboarding:dismissed` と `calendar:gridStyles` を追記