### PR TITLE
fix: 表で日をタップしたときの自動センタースクロールを抑制 (#29)

### DIFF
--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -30,7 +30,7 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
   const [clipboard, setClipboard] = useState<Partial<DayEntry>>({})
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const selectedRowRef = useRef<HTMLDivElement>(null)
-  // 表の行タップ由来の選択はスクロールさせるべき日付を記録（カレンダー由来と区別）
+  // 表内の操作（行タップ・入力フォーカス等）由来の選択日を記録する。この日付の選択ではスクロールしない（カレンダー由来と区別）
   const skipScrollDateRef = useRef<string | null>(null)
 
   // アニメーション方向を追跡
@@ -117,12 +117,12 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
       })
 
   // 選択日が変わったとき、カレンダー由来かつ画面外のときだけスクロールして見せる（showAllDaysモードのみ）。
-  // 表の行タップ由来はスクロールしない。
+  // 表内の操作由来はスクロールしない。
+  // フラグは「一度きり」の意味なので、どの経路（early return 含む）でも必ず先頭でクリアする。
   useEffect(() => {
-    if (!showAllDays || !selectedRowRef.current || !scrollContainerRef.current) return
     const fromRowTap = skipScrollDateRef.current === selectedDate
     skipScrollDateRef.current = null
-    if (fromRowTap) return
+    if (!showAllDays || !selectedRowRef.current || !scrollContainerRef.current || fromRowTap) return
     const row = selectedRowRef.current
     const container = scrollContainerRef.current
     const rowRect = row.getBoundingClientRect()

--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -30,6 +30,8 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
   const [clipboard, setClipboard] = useState<Partial<DayEntry>>({})
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const selectedRowRef = useRef<HTMLDivElement>(null)
+  // 表の行タップ由来の選択はスクロールさせるべき日付を記録（カレンダー由来と区別）
+  const skipScrollDateRef = useRef<string | null>(null)
 
   // アニメーション方向を追跡
   const prevSelectedDateRef = useRef<string | null>(null)
@@ -69,6 +71,14 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
     [clipboard, updateEntry]
   )
 
+  const handleRowSelect = useCallback(
+    (date: string) => {
+      skipScrollDateRef.current = date
+      setSelectedDate(date)
+    },
+    [setSelectedDate]
+  )
+
   const currentMonthPrefix = `${view.year}-${String(view.month + 1).padStart(2, '0')}`
   const isValidSelection = selectedDate && selectedDate.startsWith(currentMonthPrefix)
 
@@ -106,10 +116,20 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
         }
       })
 
-  // 選択日が変わったらスクロール（showAllDaysモードのみ）
+  // 選択日が変わったとき、カレンダー由来かつ画面外のときだけスクロールして見せる（showAllDaysモードのみ）。
+  // 表の行タップ由来はスクロールしない。
   useEffect(() => {
-    if (showAllDays && selectedRowRef.current && scrollContainerRef.current) {
-      selectedRowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    if (!showAllDays || !selectedRowRef.current || !scrollContainerRef.current) return
+    const fromRowTap = skipScrollDateRef.current === selectedDate
+    skipScrollDateRef.current = null
+    if (fromRowTap) return
+    const row = selectedRowRef.current
+    const container = scrollContainerRef.current
+    const rowRect = row.getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+    const fullyVisible = rowRect.top >= containerRect.top && rowRect.bottom <= containerRect.bottom
+    if (!fullyVisible) {
+      row.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }
   }, [showAllDays, selectedDate])
 
@@ -153,7 +173,7 @@ export function DayEditor({ showAllDays = false }: DayEditorProps) {
               onUpdate={updateEntry}
               onCopy={handleCopy}
               onPaste={handlePaste}
-              onSelect={setSelectedDate}
+              onSelect={handleRowSelect}
             />
           </div>
         ))}


### PR DESCRIPTION
## 関連 Issue
closes #29

## 変更内容
ワイド画面の表モード（月の全日リスト）で、選択日が変わるたびに走っていた `scrollIntoView({ block: 'center' })` を、**選択元で出し分け**るように変更。

- **表の行タップ由来の選択ではスクロールしない**（日付値 ref `skipScrollDateRef` で識別）。指でスクロール位置を合わせている最中に行が中央へジャンプする不快な挙動を排除。
- **カレンダー由来の選択は、その日が表で画面外のときだけ** `block: 'nearest'` で見せる（`getBoundingClientRect` の完全表示判定でガード）。既に見えている日は動かさない。`'center'` → `'nearest'` に変更し reveal を最小限に。
- カレンダー⇔表の双方向選択リンクはそのまま維持。

変更は `src/components/DayEditor.tsx` のみ（+24 -4）。

## 検証（ライブ A/B, 1280×800, Playwright）
| 操作 | main（旧） | 本PR |
|---|---|---|
| 表の可視行をタップ（day13, scroll@1000） | delta **−177**（中央へ再センタリング＝ジャンプ） | delta **0**（動かない）✓ |
| カレンダーで画面外の日を選択（day24） | reveal・中央寄せ（可視 22–26） | reveal・端寄せ nearest（可視 20–24）✓ |
| カレンダーで可視の日を選択（day3） | delta 0 | delta 0 ✓ |

- 表タップ時の不要スクロールが旧 −177px → 0 に。カレンダーからの画面外 reveal は維持。
- このプロジェクトはテストフレームワーク未導入のため自動テストは追加せず、実機ブラウザの A/B 比較（CLAUDE.md 完了判定ルール準拠）で検証。