### PR TITLE
fix: UI フィードバック/位置の3不具合（コピペ通知・絵文字ポップアップ位置・テーマ選択リング） #33 #34 #35

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -104,6 +104,7 @@ Font rendering: `optimizeLegibility`, antialiased.
 - Padding: `8px`
 - Border radius: `4px`
 - Selection ring: `2px inset` with accent color, 150ms easeOut
+- Copy/Paste feedback: on copy (and on a paste that actually applied), show a small accent-color toast pill centered at the top of the row for ~1.5s (`messages.copied` / `messages.pasted`). Kept inside the row bounds because the list scroll container clips overflow.
 
 ### Toggle Switch
 

--- a/src/components/CalendarThemeSelector.tsx
+++ b/src/components/CalendarThemeSelector.tsx
@@ -31,17 +31,20 @@ export function CalendarThemeSelector() {
   const { t } = useTranslation()
   const settings = useCalendarStore((state) => state.settings)
   const view = useCalendarStore((state) => state.view)
-  const getCalendarTheme = useCalendarStore((state) => state.getCalendarTheme)
-  const getCalendarGridStyle = useCalendarStore((state) => state.getCalendarGridStyle)
+  // スライスを直接購読する。getter 関数経由だと参照が安定で、テーマ/グリッド変更時に
+  // この選択リング（白枠）が再レンダされず追従しない（Canvas はスライス購読済みなので本体だけ反映される）
+  const calendarThemes = useCalendarStore((state) => state.calendarThemes)
+  const calendarGridStyles = useCalendarStore((state) => state.calendarGridStyles)
   const updateCalendarTheme = useCalendarStore((state) => state.updateCalendarTheme)
   const updateCalendarGridStyle = useCalendarStore((state) => state.updateCalendarGridStyle)
   const appTheme = APP_THEMES[settings.appTheme]
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // 現在表示中の月のテーマとグリッドスタイルを取得
-  const currentThemeId = getCalendarTheme(view.year, view.month)
-  const currentGridStyle = getCalendarGridStyle(view.year, view.month)
+  // 現在表示中の月のテーマとグリッドスタイルを取得（store の getter と同じフォールバック）
+  const monthKey = `${view.year}-${String(view.month + 1).padStart(2, '0')}`
+  const currentThemeId = calendarThemes[monthKey] ?? settings.calendarTheme
+  const currentGridStyle = calendarGridStyles[monthKey] ?? 'rounded'
 
   const handleThemeChange = (theme: CalendarThemeId) => {
     updateCalendarTheme(view.year, view.month, theme)

--- a/src/components/DayEditor.tsx
+++ b/src/components/DayEditor.tsx
@@ -32,21 +32,24 @@ export function DayEditor({ reserveBottom = 0 }: DayEditorProps) {
     navigator.clipboard.writeText(serializeEntry(entry)).catch(() => {})
   }, [])
 
+  // 実際に貼り付けたら true を返す（DayRow のフィードバック表示用）
   const handlePaste = useCallback(
-    async (date: string) => {
+    async (date: string): Promise<boolean> => {
       try {
         const systemClipboard = await navigator.clipboard.readText()
         if (systemClipboard) {
           const parsed = deserializeEntry(systemClipboard)
           if (parsed) {
             updateEntry(date, parsed)
-            return
+            return true
           }
         }
       } catch {}
       if (Object.keys(clipboard).length > 0) {
         updateEntry(date, clipboard)
+        return true
       }
+      return false
     },
     [clipboard, updateEntry]
   )

--- a/src/components/DayRow.tsx
+++ b/src/components/DayRow.tsx
@@ -18,7 +18,7 @@ interface DayRowProps {
   isSelected: boolean
   onUpdate: (date: string, updates: Partial<Omit<DayEntry, 'date'>>) => void
   onCopy: (entry: Partial<DayEntry>) => void
-  onPaste: (date: string) => void
+  onPaste: (date: string) => Promise<boolean>
   onSelect: (date: string) => void
 }
 
@@ -56,6 +56,21 @@ export function DayRow({
   const entryTimeFrom = entry?.timeFrom ?? ''
   const entryTimeTo = entry?.timeTo ?? ''
   const freeText = entry?.text ?? ''
+
+  // コピー/ペーストの完了フィードバック（行内の小さなトースト）
+  const [toast, setToast] = useState<string | null>(null)
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const showToast = (msg: string) => {
+    setToast(msg)
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    toastTimerRef.current = setTimeout(() => setToast(null), 1500)
+  }
+  useEffect(
+    () => () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    },
+    []
+  )
 
   // IME入力中フラグ（Android日本語入力対応）
   const isComposingRef = useRef(false)
@@ -168,6 +183,16 @@ export function DayRow({
       style={{ backgroundColor: appTheme.surface }}
       onClick={handleFocus}
     >
+      {/* コピー/ペースト完了トースト（行内に収める＝スクロールコンテナのクリップ対策） */}
+      {toast && (
+        <div
+          className="pointer-events-none absolute left-1/2 top-1 z-50 -translate-x-1/2 whitespace-nowrap rounded px-2 py-0.5 text-xs shadow-lg"
+          style={{ backgroundColor: appTheme.accent, color: '#ffffff' }}
+        >
+          {toast}
+        </div>
+      )}
+
       {/* 選択枠（アニメーション付き） */}
       {isSelected && (
         <motion.div
@@ -258,6 +283,7 @@ export function DayRow({
               timeTo: localTimeTo,
               text: localFreeText,
             })
+            showToast(t('messages.copied'))
           }}
           className="shrink-0 rounded px-2 py-1 text-xs transition-opacity hover:opacity-80"
           style={{ backgroundColor: appTheme.bg, color: appTheme.text }}
@@ -268,9 +294,10 @@ export function DayRow({
 
         {/* ペーストボタン */}
         <button
-          onClick={() => {
+          onClick={async () => {
             handleFocus()
-            onPaste(dateString)
+            const pasted = await onPaste(dateString)
+            if (pasted) showToast(t('messages.pasted'))
           }}
           className="shrink-0 rounded px-2 py-1 text-xs transition-opacity hover:opacity-80"
           style={{ backgroundColor: appTheme.bg, color: appTheme.text }}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -31,15 +31,17 @@ export function EmojiPicker({ onSelect, appTheme }: EmojiPickerProps) {
   const popupRef = useRef<HTMLDivElement>(null)
   const theme = APP_THEMES[appTheme]
 
-  // ポップアップ位置を計算
-  useEffect(() => {
-    if (!isOpen || !buttonRef.current) return
+  // ポップアップ位置を計算。
+  // 高さは固定見積もりだと言語(タブの flex-wrap 行数)や幅でズレてボタンから浮くため、
+  // 描画後の実寸を useLayoutEffect で測ってボタンのすぐ上に配置する（描画前に補正＝ちらつき無し）。
+  useLayoutEffect(() => {
+    if (!isOpen || !buttonRef.current || !popupRef.current) return
 
     const rect = buttonRef.current.getBoundingClientRect()
-    const popupWidth = 256 // w-64 = 16rem = 256px
-    const popupHeight = 280 // 推定高さ
+    const popupWidth = popupRef.current.offsetWidth || 256 // w-64 = 256px
+    const popupHeight = popupRef.current.offsetHeight // 実測（タブ折返しで可変）
 
-    // 画面内に収まるよう調整
+    // ボタンのすぐ上に出す
     let top = rect.top - popupHeight - 4
     let left = rect.right - popupWidth
 
@@ -54,7 +56,7 @@ export function EmojiPicker({ onSelect, appTheme }: EmojiPickerProps) {
     }
 
     setPopupPosition({ top, left })
-  }, [isOpen])
+  }, [isOpen, selectedCategory])
 
   // クリック外側で閉じる
   useEffect(() => {

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Copied to clipboard",
+    "pasted": "Pasted",
     "downloaded": "Downloaded",
     "shareFailed": "Share failed",
     "downloadFailed": "Download failed"

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Copiado al portapapeles",
+    "pasted": "Pegado",
     "downloaded": "Descargado",
     "shareFailed": "Error al compartir",
     "downloadFailed": "Error al descargar"

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Copié dans le presse-papiers",
+    "pasted": "Collé",
     "downloaded": "Téléchargé",
     "shareFailed": "Échec du partage",
     "downloadFailed": "Échec du téléchargement"

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -104,6 +104,7 @@
   },
   "messages": {
     "copied": "クリップボードにコピーしました",
+    "pasted": "貼り付けました",
     "downloaded": "ダウンロードしました",
     "shareFailed": "共有に失敗しました",
     "downloadFailed": "ダウンロードに失敗しました"

--- a/src/lib/i18n/ko.json
+++ b/src/lib/i18n/ko.json
@@ -104,6 +104,7 @@
   },
   "messages": {
     "copied": "클립보드에 복사되었습니다",
+    "pasted": "붙여넣었습니다",
     "downloaded": "다운로드 완료",
     "shareFailed": "공유 실패",
     "downloadFailed": "다운로드 실패"

--- a/src/lib/i18n/ne.json
+++ b/src/lib/i18n/ne.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "क्लिपबोर्डमा प्रतिलिपि गरियो",
+    "pasted": "टाँसियो",
     "downloaded": "डाउनलोड भयो",
     "shareFailed": "साझा गर्न असफल",
     "downloadFailed": "डाउनलोड असफल"

--- a/src/lib/i18n/pt.json
+++ b/src/lib/i18n/pt.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Copiado para a área de transferência",
+    "pasted": "Colado",
     "downloaded": "Baixado",
     "shareFailed": "Falha ao compartilhar",
     "downloadFailed": "Falha ao baixar"

--- a/src/lib/i18n/th.json
+++ b/src/lib/i18n/th.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "คัดลอกไปยังคลิปบอร์ดแล้ว",
+    "pasted": "วางแล้ว",
     "downloaded": "ดาวน์โหลดแล้ว",
     "shareFailed": "แชร์ล้มเหลว",
     "downloadFailed": "ดาวน์โหลดล้มเหลว"

--- a/src/lib/i18n/tl.json
+++ b/src/lib/i18n/tl.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Nakopya sa clipboard",
+    "pasted": "Na-paste",
     "downloaded": "Na-download",
     "shareFailed": "Nabigo ang pagbabahagi",
     "downloadFailed": "Nabigo ang pag-download"

--- a/src/lib/i18n/vi.json
+++ b/src/lib/i18n/vi.json
@@ -118,6 +118,7 @@
   },
   "messages": {
     "copied": "Đã sao chép vào clipboard",
+    "pasted": "Đã dán",
     "downloaded": "Đã tải xuống",
     "shareFailed": "Chia sẻ thất bại",
     "downloadFailed": "Tải xuống thất bại"

--- a/src/lib/i18n/zh.json
+++ b/src/lib/i18n/zh.json
@@ -104,6 +104,7 @@
   },
   "messages": {
     "copied": "已复制到剪贴板",
+    "pasted": "已粘贴",
     "downloaded": "已下载",
     "shareFailed": "分享失败",
     "downloadFailed": "下载失败"


### PR DESCRIPTION
kako-jun の実機指摘3件を修正。

## 修正内容

### #33 日付行のコピー/ペーストに完了トーストを出す（feat）
- DayRow のコピー/ペーストボタンが無反応で押せたか分からなかった
- ActionButtons と同じ message+setTimeout パターンで、行内に小さなトースト（コピー=accent色ピル）を1.5秒表示
- ペーストは実際に貼れた時だけ表示（handlePaste が boolean を返すよう変更）
- i18n: messages.copied を再利用、messages.pasted を11言語に追加

### #34 絵文字ポップアップの表示位置が上すぎる（fix）
- 原因: 高さ280px固定見積もりで配置。カテゴリタブの flex-wrap 行数が言語・幅で変わり実高さとズレてボタンから浮いていた（"幅によってベストな位置が違う"のはこのため）
- useLayoutEffect で描画後の実寸（offsetHeight）を測り、ボタンのすぐ上（gap 4px）に配置

### #35 テーマ/グリッドスタイルの選択リング（白枠）が選択に追従しない（fix）
- 原因: CalendarThemeSelector が calendarThemes/calendarGridStyles スライスを購読せず、安定参照の getter 関数しか select していなかった。update→set() しても再レンダされず白枠が動かない（Canvas はスライス購読済みなので本体だけ反映されていた）
- スライスを直接購読して currentThemeId/currentGridStyle を導出

## 検証（実ブラウザ headless Chromium / localhost:5173）
- 10/10 PASS（copyトースト表示+自動消滅 / pasteトースト / 絵文字popup gap=4.0px / グリッドリングの移動 rounded↔lined）
- スクショ: copyトースト・絵文字popup直上・罫線リング移動を目視確認

Closes #33
Closes #34
Closes #35